### PR TITLE
Ensure CRC is a positive value

### DIFF
--- a/zipstream.py
+++ b/zipstream.py
@@ -305,7 +305,7 @@ class ZipStream:
             zinfo.compress_size = compress_size
         else:
             zinfo.compress_size = file_size
-        zinfo.CRC = CRC
+        zinfo.CRC = abs(CRC)
         zinfo.file_size = file_size
         yield self.update_data_ptr(zinfo.DataDescriptor())
         self.filelist.append(zinfo)


### PR DESCRIPTION
The zip process fails when CRC is a negative value. Making the value positive fixes the problem.
Related bug: 
- https://github.com/devsnd/cherrymusic/issues/405
- https://github.com/SpiderOak/ZipStream/issues/4
